### PR TITLE
Update ArchLinux compiling instructions

### DIFF
--- a/automotive/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/automotive/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-FIND_PACKAGE (PythonInterp REQUIRED)
+FIND_PACKAGE (PythonInterp 2.7 REQUIRED)
 
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_USE_PYTHON true)

--- a/automotive/miniature/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/automotive/miniature/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-FIND_PACKAGE (PythonInterp REQUIRED)
+FIND_PACKAGE (PythonInterp 2.7 REQUIRED)
 
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_USE_PYTHON true)

--- a/automotive/odCANDataStructureGenerator/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/automotive/odCANDataStructureGenerator/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-FIND_PACKAGE (PythonInterp REQUIRED)
+FIND_PACKAGE (PythonInterp 2.7 REQUIRED)
 
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_USE_PYTHON true)

--- a/automotive/odCANDataStructureGenerator/org.opendavinci.candatamodel/src/org/opendavinci/generator/CANDataStructureGenerator.java
+++ b/automotive/odCANDataStructureGenerator/org.opendavinci.candatamodel/src/org/opendavinci/generator/CANDataStructureGenerator.java
@@ -244,7 +244,7 @@ public class CANDataStructureGenerator {
         sb.append("# along with this program; if not, write to the Free Software"); sb.append("\r\n");
         sb.append("# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA."); sb.append("\r\n");
 
-        sb.append("FIND_PACKAGE (PythonInterp)"); sb.append("\r\n");
+        sb.append("FIND_PACKAGE (PythonInterp 2.7)"); sb.append("\r\n");
 
         sb.append("IF(PYTHONINTERP_FOUND)"); sb.append("\r\n");
         sb.append("    SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)"); sb.append("\r\n");

--- a/automotive/odcantools/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/automotive/odcantools/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-FIND_PACKAGE (PythonInterp REQUIRED)
+FIND_PACKAGE (PythonInterp 2.7 REQUIRED)
 
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_USE_PYTHON true)

--- a/cmake/Modules/CheckCxxTestEnvironment.cmake
+++ b/cmake/Modules/CheckCxxTestEnvironment.cmake
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-FIND_PACKAGE (PythonInterp REQUIRED)
+FIND_PACKAGE (PythonInterp 2.7 REQUIRED)
 
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_USE_PYTHON true)

--- a/cmake/Modules/CheckPlatform.cmake
+++ b/cmake/Modules/CheckPlatform.cmake
@@ -59,7 +59,7 @@ FIND_PACKAGE (GLUT)
 
 ###########################################################################
 # Find Qt (required for odcockpit).
-FIND_PACKAGE (Qt)
+FIND_PACKAGE (Qt4)
 
 ###########################################################################
 # Find Qwt5Qt4 (required for odcockpit).

--- a/cmake/Modules/FindQwt5Qt4.cmake
+++ b/cmake/Modules/FindQwt5Qt4.cmake
@@ -16,14 +16,16 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 IF(NOT QWT5QT4_FOUND)
-    FIND_PATH(QWT5QT4_INCLUDE_DIR
-        NAMES qwt-qt4/qwt.h
-        PATHS ${LIBQWT5QT4_PATH}/include/
+    FIND_PATH(QWT5QT4_INCLUDE_DIR qwt.h
+        PATHS ${LIBQWT5QT4_PATH}/include
               /usr/local/include/
               /usr/include/
+        PATH_SUFFIXES qwt qwt5 qwt-qt4 qwt5-qt4 ENV PATH
     )
 
-    FIND_FILE(QWT5QT4_LIBRARIES libqwt-qt4.so
+    FIND_FILE(QWT5QT4_LIBRARIES
+        NAMES libqwt-qt4.so
+              libqwt5.so
         PATHS ${LIBQWT5QT4_PATH}/lib/
               /usr/local/lib64/
               /usr/local/lib/
@@ -39,8 +41,8 @@ IF(NOT QWT5QT4_FOUND)
     ENDIF()
 
     IF(QWT5QT4_FOUND)
-        MESSAGE(STATUS "Found qwt5-qt4 library: ${QWT5QT4_INCLUDE_DIR}/qwt-qt4, ${QWT5QT4_LIBRARIES}")
-        SET (QWT5QT4_INCLUDE_DIRS ${QWT5QT4_INCLUDE_DIR}/qwt-qt4)
+        MESSAGE(STATUS "Found qwt5-qt4 library: ${QWT5QT4_INCLUDE_DIR}, ${QWT5QT4_LIBRARIES}")
+        SET (QWT5QT4_INCLUDE_DIRS ${QWT5QT4_INCLUDE_DIR})
     ELSE()
         IF(Qwt5Qt4_FIND_REQUIRED)
             MESSAGE(FATAL_ERROR "Could not find qwt5-qt4 library, try to setup LIBQWT5QT4_PATH accordingly.")
@@ -49,4 +51,3 @@ IF(NOT QWT5QT4_FOUND)
         ENDIF()
     ENDIF()
 ENDIF()
-

--- a/cmake/Modules/FindQwt5Qt4.cmake
+++ b/cmake/Modules/FindQwt5Qt4.cmake
@@ -25,7 +25,9 @@ IF(NOT QWT5QT4_FOUND)
 
     FIND_FILE(QWT5QT4_LIBRARIES
         NAMES libqwt-qt4.so
+              libqwt5-qt4.so
               libqwt5.so
+              libqwt.so
         PATHS ${LIBQWT5QT4_PATH}/lib/
               /usr/local/lib64/
               /usr/local/lib/

--- a/docs/installation.archlinux.rst
+++ b/docs/installation.archlinux.rst
@@ -15,10 +15,6 @@ Install the required development packages for OpenDaVINCI sources::
 
     $ sudo pacman -S cmake gcc git make python2
 
-Add a missing symbolic link::
-
-    $ sudo ln -sf /usr/bin/python2.7 /usr/bin/python
-
 Install development packages for libodsimulation sources::
 
     $ sudo pacman -S freeglut qt4 boost opencv
@@ -26,11 +22,6 @@ Install development packages for libodsimulation sources::
 Install qwt5-qt4::
 
     $ sudo pacman -S qwt5
-
-Add two missing symbolic links::
-
-    $ sudo ln -sf /usr/include/qwt5 /usr/include/qwt-qt4
-    $ sudo ln -sf /usr/lib/libqwt5.so /usr/lib/libqwt-qt4.so
 
 .. Install the required development packages for host-tools sources:
 

--- a/docs/installation.archlinux.rst
+++ b/docs/installation.archlinux.rst
@@ -21,10 +21,7 @@ Add a missing symbolic link::
 
 Install development packages for libodsimulation sources::
 
-    $ sudo pacman -S freeglut
-    $ sudo pacman -S qt4
-    $ sudo pacman -S boost
-    $ sudo pacman -S opencv-devel
+    $ sudo pacman -S freeglut qt4 boost opencv
 
 Install qwt5-qt4::
 
@@ -33,7 +30,7 @@ Install qwt5-qt4::
 Add two missing symbolic links::
 
     $ sudo ln -sf /usr/include/qwt5 /usr/include/qwt-qt4
-    $ sudo ln -sf /usr/local/qwt-5.2.3/lib/libqwt.so.5.2.3 /usr/include/libqwt-qt4.so
+    $ sudo ln -sf /usr/lib/libqwt5.so /usr/lib/libqwt-qt4.so
 
 .. Install the required development packages for host-tools sources:
 
@@ -45,9 +42,7 @@ Add two missing symbolic links::
 
 Install the required development packages for the DataStructureGenerator sources::
 
-    $ sudo pacman -S jdk8-openjdk
-    $ sudo pacman -S apache-ant
-    $ sudo pacman -S junit
+    $ sudo pacman -S jdk8-openjdk apache-ant junit
 
 Clone the latest OpenDaVINCI sources from https://github.com/se-research/OpenDaVINCI or download
 the latest OpenDaVINCI sources as zip file: https://github.com/se-research/OpenDaVINCI/archive/master.zip.
@@ -63,7 +58,7 @@ Use cmake to create the build scripts for your build folder::
 Build, run the tests, and install the OpenDaVINCI::
 
     $ sudo make all
-    
+
 Note that sudo is used here because installing software to system-wide directories (e.g., /usr/local) requires superuser (root) privileges. If OpenDaVINCI is installed in a different directory, e.g., /opt/od, then there is no need to use sudo. Instead, write permission should be given::
 
     $ sudo chown $USER:$USER /opt/od

--- a/docs/installation.centos7.rst
+++ b/docs/installation.centos7.rst
@@ -22,11 +22,6 @@ Install qwt5-qt4 for hesperia sources::
     $ wget http://li.nux.ro/download/nux/dextop/el7/x86_64/qwt5-qt4-devel-5.2.2-26.el7.nux.x86_64.rpm
     $ sudo rpm --install qwt5*.rpm
 
-Add two missing symbolic links::
-
-    $ sudo ln -sf /usr/include/qwt5-qt4 /usr/include/qwt-qt4
-    $ sudo ln -sf /usr/lib64/libqwt5-qt4.so /usr/lib64/libqwt-qt4.so
-
 .. Install the required development packages for host-tools sources::
 
     $ sudo yum install libusb-devel

--- a/docs/installation.fedora-20.rst
+++ b/docs/installation.fedora-20.rst
@@ -15,11 +15,6 @@ Install the required development packages for libodsimulation sources::
 
     $ sudo yum install freeglut qt4 boost boost-devel qt4-devel freeglut-devel opencv-devel qwt5-qt4-devel
     
-Add two missing symbolic links::
-
-    $ sudo ln -sf /usr/include/qwt5-qt4 /usr/include/qwt-qt4
-    $ sudo ln -sf /usr/lib64/libqwt5-qt4.so /usr/lib64/libqwt-qt4.so
-
 .. Install the required development packages for host-tools sources::
 
     $sudo yum install libusb-devel

--- a/docs/installation.fedora-21.rst
+++ b/docs/installation.fedora-21.rst
@@ -27,12 +27,7 @@ Clean up installation::
 
     $ sudo yum autoremove
     $ sudo yum clean all
-  
-Add two missing symbolic links::
 
-    $ sudo ln -sf /usr/include/qwt5-qt4 /usr/include/qwt-qt4
-    $ sudo ln -sf /usr/lib64/libqwt5-qt4.so /usr/lib64/libqwt-qt4.so
-     
 Clone the latest OpenDaVINCI sources from https://github.com/se-research/OpenDaVINCI or download
 the latest OpenDaVINCI sources as zip file: https://github.com/se-research/OpenDaVINCI/archive/master.zip.
 

--- a/docs/installation.fedora-22.rst
+++ b/docs/installation.fedora-22.rst
@@ -28,11 +28,6 @@ Clean up installation::
     $ sudo dnf autoremove
     $ sudo dnf clean all
   
-Add two missing symbolic links::
-
-    $ sudo ln -sf /usr/include/qwt5-qt4 /usr/include/qwt-qt4
-    $ sudo ln -sf /usr/lib64/libqwt5-qt4.so /usr/lib64/libqwt-qt4.so
-     
 Clone the latest OpenDaVINCI sources from https://github.com/se-research/OpenDaVINCI or download
 the latest OpenDaVINCI sources as zip file: https://github.com/se-research/OpenDaVINCI/archive/master.zip.
 

--- a/docs/installation.fedora-23.rst
+++ b/docs/installation.fedora-23.rst
@@ -28,11 +28,6 @@ Clean up installation::
     $ sudo dnf autoremove
     $ sudo dnf clean all
   
-Add two missing symbolic links::
-
-    $ sudo ln -sf /usr/include/qwt5-qt4 /usr/include/qwt-qt4
-    $ sudo ln -sf /usr/lib64/libqwt5-qt4.so /usr/lib64/libqwt-qt4.so
-     
 Clone the latest OpenDaVINCI sources from https://github.com/se-research/OpenDaVINCI or download
 the latest OpenDaVINCI sources as zip file: https://github.com/se-research/OpenDaVINCI/archive/master.zip.
 

--- a/docs/installation.opensuse-13.1.rst
+++ b/docs/installation.opensuse-13.1.rst
@@ -18,12 +18,7 @@ Install required development packages for libodsimulation sources::
 
     $ sudo zypper install libusb-devel
     
-Install and configure Oracle's Java according to the following guide http://tutorialforlinux.com/2013/12/12/how-to-install-oracle-java-jdk-7-on-opensuse-13-1-gnome3-3264bit-easy-guide/
-
-Add two missing symbolic links::
-
-    $ sudo ln -sf /usr/include/qwt5 /usr/include/qwt-qt4
-    $ sudo ln -sf /usr/lib64/libqwt.so /usr/lib64/libqwt-qt4.so
+Install and configure Oracle's Java according to the following guide http://tutorialforlinux.com/2013/12/12/how-to-install-oracle-java-jdk-7-on-opensuse-13-1-gnome3-3264bit-easy-guide/ ::
 
     $ sudo apt-get install ant openjdk-7-jdk
 

--- a/docs/installation.opensuse-13.2.rst
+++ b/docs/installation.opensuse-13.2.rst
@@ -18,12 +18,7 @@ Install required development packages for libodsimulation sources::
 
     $ sudo zypper install libusb-devel
     
-Install and configure Oracle's Java according to the following guide http://tutorialforlinux.com/2013/12/12/how-to-install-oracle-java-jdk-7-on-opensuse-13-1-gnome3-3264bit-easy-guide/
-
-Add two missing symbolic links::
-
-    $ sudo ln -sf /usr/include/qwt5 /usr/include/qwt-qt4
-    $ sudo ln -sf /usr/lib64/libqwt.so /usr/lib64/libqwt-qt4.so
+Install and configure Oracle's Java according to the following guide http://tutorialforlinux.com/2013/12/12/how-to-install-oracle-java-jdk-7-on-opensuse-13-1-gnome3-3264bit-easy-guide/ ::
 
     $ sudo apt-get install ant openjdk-7-jdk
 

--- a/libodsimulation/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/libodsimulation/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-FIND_PACKAGE (PythonInterp REQUIRED)
+FIND_PACKAGE (PythonInterp 2.7 REQUIRED)
 
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_USE_PYTHON true)

--- a/libopendavinci/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/libopendavinci/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-FIND_PACKAGE (PythonInterp REQUIRED)
+FIND_PACKAGE (PythonInterp 2.7 REQUIRED)
 
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-FIND_PACKAGE (PythonInterp REQUIRED)
+FIND_PACKAGE (PythonInterp 2.7 REQUIRED)
 
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/src/org/opendavinci/generator/DataStructureGenerator.java
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/src/org/opendavinci/generator/DataStructureGenerator.java
@@ -281,7 +281,7 @@ public class DataStructureGenerator {
 		sb.append("# along with this program; if not, write to the Free Software"); sb.append("\r\n");
 		sb.append("# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA."); sb.append("\r\n");
 
-		sb.append("FIND_PACKAGE (PythonInterp)"); sb.append("\r\n");
+		sb.append("FIND_PACKAGE (PythonInterp 2.7)"); sb.append("\r\n");
 
 		sb.append("IF(PYTHONINTERP_FOUND)"); sb.append("\r\n");
 		sb.append("    SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)"); sb.append("\r\n");

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test10_withCMake/libtest10/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test10_withCMake/libtest10/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test11_withCMake/libtest11/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test11_withCMake/libtest11/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test12_withCMake/libtest12/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test12_withCMake/libtest12/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test13_withCMake/libtest13/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test13_withCMake/libtest13/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test14_withCMake/libtest14/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test14_withCMake/libtest14/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test15_withCMake/libtest15/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test15_withCMake/libtest15/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test16_withCMake/libtest16/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test16_withCMake/libtest16/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test17_withCMake/libtest17/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test17_withCMake/libtest17/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test18_withCMake/libtest18/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test18_withCMake/libtest18/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test19_withCMake/libtest19/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test19_withCMake/libtest19/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test20_withCMake/libtest20/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test20_withCMake/libtest20/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test2_withCMake/libtest2/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test2_withCMake/libtest2/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test3_withCMake/libtest3/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test3_withCMake/libtest3/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test4_withCMake/libtest4/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test4_withCMake/libtest4/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test5_withCMake/libtest5/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test5_withCMake/libtest5/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test6_withCMake/libtest6/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test6_withCMake/libtest6/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test7_withCMake/libtest7/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test7_withCMake/libtest7/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test8_withCMake/libtest8/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test8_withCMake/libtest8/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test9_withCMake/libtest9/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odDataStructureGenerator/org.opendavinci.datamodel/test/odvd/reference/Test9_withCMake/libtest9/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-FIND_PACKAGE (PythonInterp)
+FIND_PACKAGE (PythonInterp 2.7)
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_TESTGEN_ARGS --xunit-printer --have-eh)
     SET (CXXTEST_USE_PYTHON true)

--- a/odcockpit/CMakeLists.txt
+++ b/odcockpit/CMakeLists.txt
@@ -39,7 +39,7 @@ INCLUDE (CompileFlags)
 
 ###########################################################################
 # Find and configure CxxTest.
-SET (CXXTEST_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../cxxtest") 
+SET (CXXTEST_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../cxxtest")
 INCLUDE (CheckCxxTestEnvironment)
 
 ###########################################################################
@@ -82,7 +82,9 @@ INCLUDE_DIRECTORIES (${AUTOMOTIVEDATA_INCLUDE_DIRS}/automotivedata)
 # Set header files from Hesperia.
 INCLUDE_DIRECTORIES (${ODSIMULATION_INCLUDE_DIRS}/odsimulation)
 # Set header files from Qwt5-Qt4.
-INCLUDE_DIRECTORIES (${QWT5QT4_INCLUDE_DIRS})
+# Marking this with SYSTEM tells CMake to count this as a system library.
+# Used to suppress warnings from Qwt5-Qt4.
+INCLUDE_DIRECTORIES (SYSTEM ${QWT5QT4_INCLUDE_DIRS})
 # Set include directory.
 INCLUDE_DIRECTORIES(include)
 
@@ -113,13 +115,13 @@ QT4_ADD_TRANSLATION(QM ${myapp_TRANSLATIONS})
 # Artifacts from this project.
 ADD_LIBRARY (${PROJECT_NAME}lib-static STATIC ${thisproject-sources} ${odcockpit-headers-moc})
 ADD_EXECUTABLE (${PROJECT_NAME} "${CMAKE_CURRENT_SOURCE_DIR}/apps/${PROJECT_NAME}.cpp")
-TARGET_LINK_LIBRARIES (${PROJECT_NAME} ${PROJECT_NAME}lib-static ${LIBRARIES}) 
+TARGET_LINK_LIBRARIES (${PROJECT_NAME} ${PROJECT_NAME}lib-static ${LIBRARIES})
 
 ###########################################################################
 # Enable CxxTest for all available testsuites.
 IF(CXXTEST_FOUND)
     FILE(GLOB thisproject-testsuites "${CMAKE_CURRENT_SOURCE_DIR}/testsuites/*.h")
-    
+
     FOREACH(testsuite ${thisproject-testsuites})
         STRING(REPLACE "/" ";" testsuite-list ${testsuite})
 

--- a/odcockpit/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odcockpit/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-FIND_PACKAGE (PythonInterp REQUIRED)
+FIND_PACKAGE (PythonInterp 2.7 REQUIRED)
 
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_USE_PYTHON true)

--- a/odcockpit/cmake.Modules/FindQwt5Qt4.cmake
+++ b/odcockpit/cmake.Modules/FindQwt5Qt4.cmake
@@ -16,14 +16,16 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 IF(NOT QWT5QT4_FOUND)
-    FIND_PATH(QWT5QT4_INCLUDE_DIR
-        NAMES qwt-qt4/qwt.h
-        PATHS ${LIBQWT5QT4_PATH}/include/
+    FIND_PATH(QWT5QT4_INCLUDE_DIR qwt.h
+        PATHS ${LIBQWT5QT4_PATH}/include
               /usr/local/include/
               /usr/include/
+        PATH_SUFFIXES qwt qwt5 qwt-qt4 qwt5-qt4 ENV PATH
     )
 
-    FIND_FILE(QWT5QT4_LIBRARIES libqwt-qt4.so
+    FIND_FILE(QWT5QT4_LIBRARIES
+        NAMES libqwt-qt4.so
+              libqwt5.so
         PATHS ${LIBQWT5QT4_PATH}/lib/
               /usr/local/lib64/
               /usr/local/lib/
@@ -39,8 +41,8 @@ IF(NOT QWT5QT4_FOUND)
     ENDIF()
 
     IF(QWT5QT4_FOUND)
-        MESSAGE(STATUS "Found qwt5-qt4 library: ${QWT5QT4_INCLUDE_DIR}/qwt-qt4, ${QWT5QT4_LIBRARIES}")
-        SET (QWT5QT4_INCLUDE_DIRS ${QWT5QT4_INCLUDE_DIR}/qwt-qt4)
+        MESSAGE(STATUS "Found qwt5-qt4 library: ${QWT5QT4_INCLUDE_DIR}, ${QWT5QT4_LIBRARIES}")
+        SET (QWT5QT4_INCLUDE_DIRS ${QWT5QT4_INCLUDE_DIR})
     ELSE()
         IF(Qwt5Qt4_FIND_REQUIRED)
             MESSAGE(FATAL_ERROR "Could not find qwt5-qt4 library, try to setup LIBQWT5QT4_PATH accordingly.")
@@ -49,4 +51,3 @@ IF(NOT QWT5QT4_FOUND)
         ENDIF()
     ENDIF()
 ENDIF()
-

--- a/odcockpit/cmake.Modules/FindQwt5Qt4.cmake
+++ b/odcockpit/cmake.Modules/FindQwt5Qt4.cmake
@@ -25,7 +25,9 @@ IF(NOT QWT5QT4_FOUND)
 
     FIND_FILE(QWT5QT4_LIBRARIES
         NAMES libqwt-qt4.so
+              libqwt5-qt4.so
               libqwt5.so
+              libqwt.so
         PATHS ${LIBQWT5QT4_PATH}/lib/
               /usr/local/lib64/
               /usr/local/lib/

--- a/odcockpit/include/plugins/iruscharts/IrUsChartData.h
+++ b/odcockpit/include/plugins/iruscharts/IrUsChartData.h
@@ -30,7 +30,7 @@
 #elif defined _MSC_VER
 #pragma warning(push, 1)
 #endif
-    #include <qwt-qt4/qwt_data.h>
+    #include <qwt_data.h>
 #if defined __SUNPRO_CC
 #pragma enable_warn
 #elif defined _MSC_VER
@@ -96,4 +96,3 @@ namespace cockpit {
 }
 
 #endif /*COCKPIT_PLUGINS_IRUSCHARTS_IRUSCHARTDATA_H_*/
-

--- a/odcockpit/include/plugins/iruscharts/IrUsChartsWidget.h
+++ b/odcockpit/include/plugins/iruscharts/IrUsChartsWidget.h
@@ -109,4 +109,3 @@ class IrUsChartData;
 }
 
 #endif /*COCKPIT_PLUGINS_IRUSCHARTS_IRUSCHARTSWIDGET_H_*/
-

--- a/odcockpit/include/plugins/modulestatisticsviewer/LoadPlot.h
+++ b/odcockpit/include/plugins/modulestatisticsviewer/LoadPlot.h
@@ -30,7 +30,7 @@
 #elif defined _MSC_VER
 #pragma warning(push, 1)
 #endif
-    #include <qwt-qt4/qwt_plot.h>
+    #include <qwt_plot.h>
 #if defined __SUNPRO_CC
 #pragma enable_warn
 #elif defined _MSC_VER

--- a/odcockpit/src/plugins/GLControlFrame.cpp
+++ b/odcockpit/src/plugins/GLControlFrame.cpp
@@ -28,7 +28,7 @@
 # endif
 # pragma GCC diagnostic ignored "-Weffc++"
 #endif
-    #include <qwt-qt4/qwt_wheel.h>
+    #include <qwt_wheel.h>
 #ifndef WIN32
 # if !defined(__OpenBSD__) && !defined(__NetBSD__)
 #  pragma GCC diagnostic pop
@@ -107,4 +107,3 @@ namespace cockpit {
         }
     }
 } // cockpit::plugins
-

--- a/odcockpit/src/plugins/iruscharts/IrUsChartsWidget.cpp
+++ b/odcockpit/src/plugins/iruscharts/IrUsChartsWidget.cpp
@@ -33,9 +33,9 @@
 # endif
 # pragma GCC diagnostic ignored "-Weffc++"
 #endif
-    #include <qwt-qt4/qwt_plot.h>
-    #include <qwt-qt4/qwt_plot_curve.h>
-    #include <qwt-qt4/qwt_plot_item.h>
+    #include <qwt_plot.h>
+    #include <qwt_plot_curve.h>
+    #include <qwt_plot_item.h>
 #ifndef WIN32
 # if !defined(__OpenBSD__) && !defined(__NetBSD__)
 #  pragma GCC diagnostic pop
@@ -286,4 +286,3 @@ namespace cockpit {
         }
     }
 }
-

--- a/odcockpit/src/plugins/modulestatisticsviewer/LoadPerModule.cpp
+++ b/odcockpit/src/plugins/modulestatisticsviewer/LoadPerModule.cpp
@@ -26,8 +26,8 @@
 # endif
 # pragma GCC diagnostic ignored "-Weffc++"
 #endif
-    #include <qwt-qt4/qwt_plot_curve.h>
-    #include <qwt-qt4/qwt_plot_item.h>
+    #include <qwt_plot_curve.h>
+    #include <qwt_plot_item.h>
 #ifndef WIN32
 # if !defined(__OpenBSD__) && !defined(__NetBSD__)
 #  pragma GCC diagnostic pop

--- a/odcockpit/src/plugins/modulestatisticsviewer/LoadPlot.cpp
+++ b/odcockpit/src/plugins/modulestatisticsviewer/LoadPlot.cpp
@@ -29,8 +29,8 @@
 # endif
 # pragma GCC diagnostic ignored "-Weffc++"
 #endif
-    #include <qwt-qt4/qwt_legend.h>
-    #include <qwt-qt4/qwt_plot_curve.h>
+    #include <qwt_legend.h>
+    #include <qwt_plot_curve.h>
 #ifndef WIN32
 # if !defined(__OpenBSD__) && !defined(__NetBSD__)
 #  pragma GCC diagnostic pop
@@ -88,4 +88,3 @@ namespace cockpit {
         }
     }
 }
-

--- a/odsimulation/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odsimulation/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-FIND_PACKAGE (PythonInterp REQUIRED)
+FIND_PACKAGE (PythonInterp 2.7 REQUIRED)
 
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_USE_PYTHON true)

--- a/odsupercomponent/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odsupercomponent/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-FIND_PACKAGE (PythonInterp REQUIRED)
+FIND_PACKAGE (PythonInterp 2.7 REQUIRED)
 
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_USE_PYTHON true)

--- a/odtools/cmake.Modules/CheckCxxTestEnvironment.cmake
+++ b/odtools/cmake.Modules/CheckCxxTestEnvironment.cmake
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-FIND_PACKAGE (PythonInterp REQUIRED)
+FIND_PACKAGE (PythonInterp 2.7 REQUIRED)
 
 IF(PYTHONINTERP_FOUND)
     SET (CXXTEST_USE_PYTHON true)


### PR DESCRIPTION
Fixed references to non-existing package and wrongly pointed symlinks.

Tested and compiling with minor problems. CMake finds `qwt5-qt4` but for some reason it will not compile `odcockpit` by default. 
I "fixed" this by commenting out line 101-102 & 105-106 (the IF for Qt4 and QWT5QT4) in `CMakeLists.txt` to force CMake to create build instructions for `odcockpit`. 

This might not be a nice solution but I have little experience using CMake and I'm sure someone else can fix it.
