### PR TITLE
Fix strange memory error in CANDevice

### DIFF
--- a/automotive/odcantools/libodcantools/src/CANDevice.cpp
+++ b/automotive/odcantools/libodcantools/src/CANDevice.cpp
@@ -138,7 +138,7 @@ namespace automotive {
                     uint64_t data = 0;
                     for (uint8_t i = 0; i < message.Msg.LEN; i++) {
                         CLOG1 << static_cast<uint32_t>(message.Msg.DATA[i]) << " ";
-                        data |= (message.Msg.DATA[i] << ((message.Msg.LEN-1-i)*8));
+                        data |= (static_cast<uint64_t>(message.Msg.DATA[i]) << ((message.Msg.LEN-1-i)*8));
                     }
                     CLOG1 << endl;
                     gcm.setData(data);


### PR DESCRIPTION
- reading can data now works correctly
- fixes Roadscape
