### PR TITLE
2016Q4.fixing.pragma.macos

### DIFF
--- a/libopendavinci/include/opendavinci/odcore/base/KeyValueConfiguration.h
+++ b/libopendavinci/include/opendavinci/odcore/base/KeyValueConfiguration.h
@@ -154,7 +154,9 @@ namespace odcore {
                         odcore::data::LogMessage lm("odcore::base::KeyValueConfiguration", odcore::data::LogMessage::LogLevel::INFO, s.str());
                         #pragma GCC diagnostic push
                         #pragma GCC diagnostic ignored "-Wuninitialized"
-                        #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+                        #ifndef __APPLE__
+                            #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+                        #endif
                         return value;
                         #pragma GCC diagnostic pop
                     }


### PR DESCRIPTION
Ensuring that the pragma works for all systems except MacOS as it is unsupported in the current MacOS official clang versions.