### PR TITLE
2017Q1.test.nextcontainer

### DIFF
--- a/libopendavinci/include/opendavinci/odcore/io/conference/ContainerConference.h
+++ b/libopendavinci/include/opendavinci/odcore/io/conference/ContainerConference.h
@@ -116,6 +116,8 @@ class ContainerListener;
                 private:
                     mutable base::Mutex m_containerListenerMutex;
                     ContainerListener *m_containerListener;
+
+                    mutable base::Mutex m_senderStampMutex;
                     uint32_t m_senderStamp;
             };
 

--- a/libopendavinci/include/opendavinci/odcore/io/conference/UDPMultiCastContainerConference.h
+++ b/libopendavinci/include/opendavinci/odcore/io/conference/UDPMultiCastContainerConference.h
@@ -24,6 +24,7 @@
 #include <string>
 
 #include "opendavinci/odcore/opendavinci.h"
+#include "opendavinci/odcore/base/Mutex.h"
 #include "opendavinci/odcore/exceptions/Exceptions.h"
 #include "opendavinci/odcore/io/StringListener.h"
 #include "opendavinci/odcore/io/conference/ContainerConference.h"
@@ -83,6 +84,7 @@ namespace odcore {
 
                 private:
                     std::shared_ptr<odcore::io::udp::UDPSender> m_sender;
+                    odcore::base::Mutex m_receiveMutex;
                     std::shared_ptr<odcore::io::udp::UDPReceiver> m_receiver;
             };
 

--- a/libopendavinci/include/opendavinci/odcore/io/conference/UDPMultiCastContainerConference.h
+++ b/libopendavinci/include/opendavinci/odcore/io/conference/UDPMultiCastContainerConference.h
@@ -24,7 +24,6 @@
 #include <string>
 
 #include "opendavinci/odcore/opendavinci.h"
-#include "opendavinci/odcore/base/Mutex.h"
 #include "opendavinci/odcore/exceptions/Exceptions.h"
 #include "opendavinci/odcore/io/StringListener.h"
 #include "opendavinci/odcore/io/conference/ContainerConference.h"
@@ -84,7 +83,6 @@ namespace odcore {
 
                 private:
                     std::shared_ptr<odcore::io::udp::UDPSender> m_sender;
-                    odcore::base::Mutex m_receiveMutex;
                     std::shared_ptr<odcore::io::udp::UDPReceiver> m_receiver;
             };
 

--- a/libopendavinci/include/opendavinci/odcore/io/udp/UDPReceiver.h
+++ b/libopendavinci/include/opendavinci/odcore/io/udp/UDPReceiver.h
@@ -120,6 +120,15 @@ namespace odcore {
 
                     virtual void setPacketListener(PacketListener *pl);
 
+                    /**
+                     * This method sets the port to be ignored to receive from
+                     * to avoid circular data sending and receiving from the
+                     * same process.
+                     *
+                     * @param p Port to ignore.
+                     */
+                    virtual void setSenderPortToIgnore(const uint16_t &portToIgnore) = 0;
+
                 protected:
                     /**
                      * This method is called from deriving classes to

--- a/libopendavinci/include/opendavinci/odcore/io/udp/UDPSender.h
+++ b/libopendavinci/include/opendavinci/odcore/io/udp/UDPSender.h
@@ -67,6 +67,13 @@ namespace odcore {
                      * @param data Data to be sent.
                      */
                     virtual void send(const string &data) const = 0;
+
+                    /**
+                     * This method returns the port in use when sending UDP packets.
+                     *
+                     * @return Port when sending UDP packets.
+                     */
+                    virtual uint16_t getPort() const = 0;
             };
 
         }

--- a/libopendavinci/include/opendavinci/odcore/wrapper/POSIX/POSIXUDPReceiver.h
+++ b/libopendavinci/include/opendavinci/odcore/wrapper/POSIX/POSIXUDPReceiver.h
@@ -85,7 +85,10 @@ namespace odcore {
 
                     virtual void stop();
 
+                    virtual void setSenderPortToIgnore(const uint16_t &portToIgnore);
+
                 private:
+                    uint16_t m_portToIgnore;
                     bool m_isMulticast;
                     struct sockaddr_in m_address;
                     struct ip_mreq m_mreq;

--- a/libopendavinci/include/opendavinci/odcore/wrapper/POSIX/POSIXUDPSender.h
+++ b/libopendavinci/include/opendavinci/odcore/wrapper/POSIX/POSIXUDPSender.h
@@ -81,7 +81,10 @@ namespace odcore {
 
                     virtual void send(const string &data) const;
 
+                    virtual uint16_t getPort() const;
+
                 private:
+                    uint16_t m_sendPort;
                     struct sockaddr_in m_address;
                     int32_t m_fd;
 

--- a/libopendavinci/include/opendavinci/odcore/wrapper/POSIX/POSIXUDPSender.h
+++ b/libopendavinci/include/opendavinci/odcore/wrapper/POSIX/POSIXUDPSender.h
@@ -84,7 +84,7 @@ namespace odcore {
                     virtual uint16_t getPort() const;
 
                 private:
-                    uint16_t m_sendPort;
+                    uint16_t m_sendingUDPPort;
                     struct sockaddr_in m_address;
                     int32_t m_fd;
 

--- a/libopendavinci/src/odcore/io/StringPipeline.cpp
+++ b/libopendavinci/src/odcore/io/StringPipeline.cpp
@@ -17,8 +17,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <iostream>
-
 #include "opendavinci/odcore/base/Lock.h"
 #include "opendavinci/odcore/io/StringPipeline.h"
 
@@ -80,6 +78,7 @@ namespace odcore {
                 {
                     Lock l2(m_queueMutex);
                     entry = m_queue.front();
+                    m_queue.pop();
                 }
 
                 // Read all entries and distribute using the stringListener.
@@ -89,12 +88,6 @@ namespace odcore {
                         // Distribute entry to connected listeners while NOT locking the queue.
                         m_stringListener->nextString(entry);
                     }
-                }
-
-                // Remove processed entry.
-                {
-                    Lock l2(m_queueMutex);
-                    m_queue.pop();
                 }
             }
         }

--- a/libopendavinci/src/odcore/io/StringPipeline.cpp
+++ b/libopendavinci/src/odcore/io/StringPipeline.cpp
@@ -17,6 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include <iostream>
+
 #include "opendavinci/odcore/base/Lock.h"
 #include "opendavinci/odcore/io/StringPipeline.h"
 
@@ -51,19 +53,34 @@ namespace odcore {
         }
 
         void StringPipeline::nextString(const string &s) {
-            Lock l(m_queueCondition);
+// Read all entries and distribute using the stringListener.
+{
+    Lock l(m_stringListenerMutex);
+    if (m_stringListener != NULL) {
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
+        // Distribute entry to connected listeners while NOT locking the queue.
+        m_stringListener->nextString(s);
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
+    }
+}
 
-            // Enter new data.
-            {
-                Lock l2(m_queueMutex);
-                m_queue.push(s);
-            }
+//std::cout << __FILE__ << " " << __LINE__ << std::endl;
+//            Lock l(m_queueCondition);
+//std::cout << __FILE__ << " " << __LINE__ << std::endl;
 
-            // Wake awaiting threads.
-            m_queueCondition.wakeAll();
+//            // Enter new data.
+//            {
+//                Lock l2(m_queueMutex);
+//                m_queue.push(s);
+//            }
+
+//            // Wake awaiting threads.
+//            m_queueCondition.wakeAll();
+//std::cout << __FILE__ << " " << __LINE__ << std::endl;
         }
 
         void StringPipeline::processQueue() {
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
             uint32_t numberOfEntries = 0;
 
             // Determine the amount of current entries.
@@ -72,29 +89,28 @@ namespace odcore {
                 numberOfEntries = static_cast<uint32_t>(m_queue.size());
             }
 
+std::cout << __FILE__ << " " << __LINE__ << ", clearing = " << numberOfEntries << std::endl;
             string entry;
             for (uint32_t i = 0; i < numberOfEntries; i++) {
-                // Acquire next entry.
+                // Acquire and remove next entry.
                 {
                     Lock l2(m_queueMutex);
                     entry = m_queue.front();
+                    m_queue.pop();
                 }
 
                 // Read all entries and distribute using the stringListener.
                 {
                     Lock l(m_stringListenerMutex);
                     if (m_stringListener != NULL) {
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
                         // Distribute entry to connected listeners while NOT locking the queue.
                         m_stringListener->nextString(entry);
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
                     }
                 }
-
-                // Remove processed entry.
-                {
-                    Lock l2(m_queueMutex);
-                    m_queue.pop();
-                }
             }
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
         }
 
         void StringPipeline::beforeStop() {
@@ -111,12 +127,12 @@ namespace odcore {
                 m_queueCondition.waitOnSignal();
 
                 if (isRunning()) {
-                    processQueue();
+//                    processQueue();
                 }
             }
 
             // Procee the queue to release any further waiting entries before shutting down.
-            processQueue();
+//            processQueue();
         }
 
     }

--- a/libopendavinci/src/odcore/io/conference/ContainerConference.cpp
+++ b/libopendavinci/src/odcore/io/conference/ContainerConference.cpp
@@ -17,6 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include <iostream>
+
 #include "opendavinci/odcore/base/Lock.h"
 #include "opendavinci/odcore/io/conference/ContainerConference.h"
 #include "opendavinci/odcore/io/conference/ContainerListener.h"
@@ -68,9 +70,11 @@ namespace odcore {
             }
 
             void ContainerConference::receive(Container &c) {
-                Lock l(m_containerListenerMutex);
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
+//                Lock l(m_containerListenerMutex);
                 if (m_containerListener != NULL) {
                     m_containerListener->nextContainer(c);
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
                 }
             }
 

--- a/libopendavinci/src/odcore/io/conference/ContainerConference.cpp
+++ b/libopendavinci/src/odcore/io/conference/ContainerConference.cpp
@@ -17,8 +17,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <iostream>
-
 #include "opendavinci/odcore/base/Lock.h"
 #include "opendavinci/odcore/io/conference/ContainerConference.h"
 #include "opendavinci/odcore/io/conference/ContainerListener.h"
@@ -51,12 +49,12 @@ namespace odcore {
             }
 
             void ContainerConference::setSenderStamp(const uint32_t &senderStamp) {
-                Lock l(m_containerListenerMutex);
+//                Lock l(m_containerListenerMutex);
                 m_senderStamp = senderStamp;
             }
 
             uint32_t ContainerConference::getSenderStamp() const {
-                Lock l(m_containerListenerMutex);
+//                Lock l(m_containerListenerMutex);
                 return m_senderStamp;
             }
 
@@ -70,11 +68,9 @@ namespace odcore {
             }
 
             void ContainerConference::receive(Container &c) {
-std::cout << __FILE__ << " " << __LINE__ << std::endl;
-//                Lock l(m_containerListenerMutex);
+                Lock l(m_containerListenerMutex);
                 if (m_containerListener != NULL) {
                     m_containerListener->nextContainer(c);
-std::cout << __FILE__ << " " << __LINE__ << std::endl;
                 }
             }
 

--- a/libopendavinci/src/odcore/io/conference/ContainerConference.cpp
+++ b/libopendavinci/src/odcore/io/conference/ContainerConference.cpp
@@ -34,6 +34,7 @@ namespace odcore {
             ContainerConference::ContainerConference() :
                 m_containerListenerMutex(),
                 m_containerListener(NULL),
+                m_senderStampMutex(),
                 m_senderStamp(0) {}
 
             ContainerConference::~ContainerConference() {}
@@ -49,10 +50,12 @@ namespace odcore {
             }
 
             void ContainerConference::setSenderStamp(const uint32_t &senderStamp) {
+                Lock l(m_senderStampMutex);
                 m_senderStamp = senderStamp;
             }
 
             uint32_t ContainerConference::getSenderStamp() const {
+                Lock l(m_senderStampMutex);
                 return m_senderStamp;
             }
 

--- a/libopendavinci/src/odcore/io/conference/ContainerConference.cpp
+++ b/libopendavinci/src/odcore/io/conference/ContainerConference.cpp
@@ -49,12 +49,10 @@ namespace odcore {
             }
 
             void ContainerConference::setSenderStamp(const uint32_t &senderStamp) {
-//                Lock l(m_containerListenerMutex);
                 m_senderStamp = senderStamp;
             }
 
             uint32_t ContainerConference::getSenderStamp() const {
-//                Lock l(m_containerListenerMutex);
                 return m_senderStamp;
             }
 

--- a/libopendavinci/src/odcore/io/conference/UDPMultiCastContainerConference.cpp
+++ b/libopendavinci/src/odcore/io/conference/UDPMultiCastContainerConference.cpp
@@ -40,7 +40,6 @@ namespace odcore {
 
             UDPMultiCastContainerConference::UDPMultiCastContainerConference(const string &address, const uint32_t &port) throw (ConferenceException) :
                 m_sender(NULL),
-                m_receiveMutex(),
                 m_receiver(NULL) {
                 try {
                     m_sender = odcore::io::udp::UDPFactory::createUDPSender(address, port);
@@ -52,7 +51,7 @@ std::cout << "UDPSender: " << m_sender->getPort() << std::endl;
 
                 try {
                     m_receiver = odcore::io::udp::UDPFactory::createUDPReceiver(address, port);
-//m_receiver->setSenderPortToIgnore(m_sender->getPort());
+m_receiver->setSenderPortToIgnore(m_sender->getPort());
                 }
                 catch (string &s) {
                     OPENDAVINCI_CORE_THROW_EXCEPTION(ConferenceException, s);
@@ -74,29 +73,20 @@ std::cout << "UDPSender: " << m_sender->getPort() << std::endl;
             }
 
             void UDPMultiCastContainerConference::nextString(const string &s) {
-std::cout << __FILE__ << " " << __LINE__ << std::endl;
-                Lock l(m_receiveMutex);
-std::cout << __FILE__ << " " << __LINE__ << std::endl;
                 if (hasContainerListener()) {
-std::cout << __FILE__ << " " << __LINE__ << std::endl;
                     Container container;
-std::cout << __FILE__ << " " << __LINE__ << std::endl;
 
                     stringstream stringstreamData(s);
                     stringstreamData >> container;
-std::cout << __FILE__ << " " << __LINE__ << std::endl;
 
                     container.setReceivedTimeStamp(TimeStamp());
-std::cout << __FILE__ << " " << __LINE__ << std::endl;
 
                     // Use superclass to distribute any received containers.
                     receive(container);
-std::cout << __FILE__ << " " << __LINE__ << std::endl;
                 }
             }
 
             void UDPMultiCastContainerConference::send(Container &container) const {
-std::cout << __FILE__ << " " << __LINE__ << std::endl;
                 // Set sending time stamp.
                 container.setSentTimeStamp(TimeStamp());
 
@@ -118,7 +108,6 @@ std::cout << __FILE__ << " " << __LINE__ << std::endl;
 
                 // Send data.
                 m_sender->send(stringValue);
-std::cout << __FILE__ << " " << __LINE__ << std::endl;
             }
 
         }

--- a/libopendavinci/src/odcore/io/conference/UDPMultiCastContainerConference.cpp
+++ b/libopendavinci/src/odcore/io/conference/UDPMultiCastContainerConference.cpp
@@ -18,9 +18,11 @@
  */
 
 #include <iosfwd>
+#include <iostream>
 #include <sstream>
 
 #include "opendavinci/odcore/serialization/Serializable.h"
+#include "opendavinci/odcore/base/Lock.h"
 #include "opendavinci/odcore/data/Container.h"
 #include "opendavinci/odcore/data/TimeStamp.h"
 #include "opendavinci/odcore/io/conference/UDPMultiCastContainerConference.h"
@@ -38,9 +40,11 @@ namespace odcore {
 
             UDPMultiCastContainerConference::UDPMultiCastContainerConference(const string &address, const uint32_t &port) throw (ConferenceException) :
                 m_sender(NULL),
+                m_receiveMutex(),
                 m_receiver(NULL) {
                 try {
                     m_sender = odcore::io::udp::UDPFactory::createUDPSender(address, port);
+std::cout << "UDPSender: " << m_sender->getPort() << std::endl;
                 }
                 catch (string &s) {
                     OPENDAVINCI_CORE_THROW_EXCEPTION(ConferenceException, s);
@@ -48,6 +52,7 @@ namespace odcore {
 
                 try {
                     m_receiver = odcore::io::udp::UDPFactory::createUDPReceiver(address, port);
+//m_receiver->setSenderPortToIgnore(m_sender->getPort());
                 }
                 catch (string &s) {
                     OPENDAVINCI_CORE_THROW_EXCEPTION(ConferenceException, s);
@@ -69,20 +74,29 @@ namespace odcore {
             }
 
             void UDPMultiCastContainerConference::nextString(const string &s) {
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
+                Lock l(m_receiveMutex);
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
                 if (hasContainerListener()) {
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
                     Container container;
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
 
                     stringstream stringstreamData(s);
                     stringstreamData >> container;
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
 
                     container.setReceivedTimeStamp(TimeStamp());
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
 
                     // Use superclass to distribute any received containers.
                     receive(container);
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
                 }
             }
 
             void UDPMultiCastContainerConference::send(Container &container) const {
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
                 // Set sending time stamp.
                 container.setSentTimeStamp(TimeStamp());
 
@@ -104,6 +118,7 @@ namespace odcore {
 
                 // Send data.
                 m_sender->send(stringValue);
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
             }
 
         }

--- a/libopendavinci/src/odcore/io/conference/UDPMultiCastContainerConference.cpp
+++ b/libopendavinci/src/odcore/io/conference/UDPMultiCastContainerConference.cpp
@@ -18,11 +18,9 @@
  */
 
 #include <iosfwd>
-#include <iostream>
 #include <sstream>
 
 #include "opendavinci/odcore/serialization/Serializable.h"
-#include "opendavinci/odcore/base/Lock.h"
 #include "opendavinci/odcore/data/Container.h"
 #include "opendavinci/odcore/data/TimeStamp.h"
 #include "opendavinci/odcore/io/conference/UDPMultiCastContainerConference.h"

--- a/libopendavinci/src/odcore/io/conference/UDPMultiCastContainerConference.cpp
+++ b/libopendavinci/src/odcore/io/conference/UDPMultiCastContainerConference.cpp
@@ -43,7 +43,6 @@ namespace odcore {
                 m_receiver(NULL) {
                 try {
                     m_sender = odcore::io::udp::UDPFactory::createUDPSender(address, port);
-std::cout << "UDPSender: " << m_sender->getPort() << std::endl;
                 }
                 catch (string &s) {
                     OPENDAVINCI_CORE_THROW_EXCEPTION(ConferenceException, s);
@@ -51,7 +50,8 @@ std::cout << "UDPSender: " << m_sender->getPort() << std::endl;
 
                 try {
                     m_receiver = odcore::io::udp::UDPFactory::createUDPReceiver(address, port);
-m_receiver->setSenderPortToIgnore(m_sender->getPort());
+                    // Disable circular receiving of data sent by ourselves.
+                    m_receiver->setSenderPortToIgnore(m_sender->getPort());
                 }
                 catch (string &s) {
                     OPENDAVINCI_CORE_THROW_EXCEPTION(ConferenceException, s);

--- a/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPReceiver.cpp
+++ b/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPReceiver.cpp
@@ -145,7 +145,8 @@ namespace odcore {
                             char remoteAddr[MAX_ADDR_SIZE];
                             inet_ntop(remote.ss_family, &((reinterpret_cast<struct sockaddr_in*>(&remote))->sin_addr), remoteAddr, sizeof(remoteAddr));
 
-                            const uint16_t recvPort = ntohs(((struct sockaddr_in *)&remote)->sin_port);
+//                            const uint16_t recvPort = ntohs(((struct sockaddr_in *)&remote)->sin_port);
+                            const uint16_t recvPort = ntohs(reinterpret_cast<struct sockaddr_in*>(&remote)->sin_port);
                             if (m_portToIgnore != recvPort) {
                                 // ----------------------v (remote address)--v (data)
                                 nextPacket(odcore::io::Packet(string(remoteAddr), string(m_buffer, nbytes)));

--- a/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPReceiver.cpp
+++ b/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPReceiver.cpp
@@ -23,6 +23,7 @@
 
 #include <cerrno>
 #include <cstring>
+#include <iostream>
 #include <sstream>
 
 #include "opendavinci/odcore/io/Packet.h"
@@ -37,6 +38,7 @@ namespace odcore {
             using namespace std;
 
             POSIXUDPReceiver::POSIXUDPReceiver(const string &address, const uint32_t &port, const bool &isMulticast) :
+                m_portToIgnore(0),
                 m_isMulticast(isMulticast),
                 m_address(),
                 m_mreq(),
@@ -113,6 +115,10 @@ namespace odcore {
                 m_buffer = NULL;
             }
 
+            void POSIXUDPReceiver::setSenderPortToIgnore(const uint16_t &portToIgnore) {
+                m_portToIgnore = portToIgnore;
+            }
+
             void POSIXUDPReceiver::run() {
                 fd_set rfds;
                 struct timeval timeout;
@@ -140,8 +146,14 @@ namespace odcore {
                             char remoteAddr[MAX_ADDR_SIZE];
                             inet_ntop(remote.ss_family, &((reinterpret_cast<struct sockaddr_in*>(&remote))->sin_addr), remoteAddr, sizeof(remoteAddr));
 
-                            // ----------------------v (remote address)--v (data)
-                            nextPacket(odcore::io::Packet(string(remoteAddr), string(m_buffer, nbytes)));
+                            const uint16_t recvPort = ntohs(((struct sockaddr_in *)&remote)->sin_port);
+                            if (m_portToIgnore != recvPort) {
+                                // ----------------------v (remote address)--v (data)
+                                nextPacket(odcore::io::Packet(string(remoteAddr), string(m_buffer, nbytes)));
+                            }
+else {
+std::cout << "Dropped packet to avoid circular sending/receiving." << std::endl;
+}
                         }
                     }
                 }

--- a/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPReceiver.cpp
+++ b/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPReceiver.cpp
@@ -23,7 +23,6 @@
 
 #include <cerrno>
 #include <cstring>
-#include <iostream>
 #include <sstream>
 
 #include "opendavinci/odcore/io/Packet.h"
@@ -151,9 +150,6 @@ namespace odcore {
                                 // ----------------------v (remote address)--v (data)
                                 nextPacket(odcore::io::Packet(string(remoteAddr), string(m_buffer, nbytes)));
                             }
-else {
-std::cout << "Dropped packet to avoid circular sending/receiving." << std::endl;
-}
                         }
                     }
                 }

--- a/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPReceiver.cpp
+++ b/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPReceiver.cpp
@@ -145,7 +145,6 @@ namespace odcore {
                             char remoteAddr[MAX_ADDR_SIZE];
                             inet_ntop(remote.ss_family, &((reinterpret_cast<struct sockaddr_in*>(&remote))->sin_addr), remoteAddr, sizeof(remoteAddr));
 
-//                            const uint16_t recvPort = ntohs(((struct sockaddr_in *)&remote)->sin_port);
                             const uint16_t recvPort = ntohs(reinterpret_cast<struct sockaddr_in*>(&remote)->sin_port);
                             if (m_portToIgnore != recvPort) {
                                 // ----------------------v (remote address)--v (data)

--- a/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPSender.cpp
+++ b/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPSender.cpp
@@ -21,8 +21,6 @@
 
 #include <cerrno>
 #include <cstring>
-
-#include <iostream>
 #include <sstream>
 
 #include "opendavinci/odcore/wrapper/Mutex.h"
@@ -100,13 +98,11 @@ namespace odcore {
                     throw s.str();
                 }
 
-std::cout << __FILE__ << " " << __LINE__ << std::endl;
                 m_socketMutex->lock();
                 {
                     sendto(m_fd, data.c_str(), data.length(), 0, reinterpret_cast<const struct sockaddr *>(&m_address), sizeof(m_address));
                 }
                 m_socketMutex->unlock();
-std::cout << __FILE__ << " " << __LINE__ << std::endl;
             }
 
         }

--- a/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPSender.cpp
+++ b/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPSender.cpp
@@ -34,7 +34,7 @@ namespace odcore {
             using namespace std;
 
             POSIXUDPSender::POSIXUDPSender(const string &address, const uint32_t &port) :
-                m_sendPort(0),
+                m_sendingUDPPort(0),
                 m_address(),
                 m_fd(),
                 m_socketMutex() {
@@ -70,7 +70,8 @@ namespace odcore {
                     s << "[core::wrapper::POSIXUDPSender] Error while retrieving properties from socket: " << strerror(errno);
                     throw s.str();
                 }
-                m_sendPort = ntohs(((struct sockaddr_in *)&addr)->sin_port);
+//                m_sendingUDPPort = ntohs(((struct sockaddr_in *)&addr)->sin_port);
+                m_sendingUDPPort = ntohs(reinterpret_cast<struct sockaddr_in*>(&addr)->sin_port);
 
                 // Setup address and port to be used for sending to.
                 memset(&m_address, 0, sizeof(m_address));
@@ -88,7 +89,7 @@ namespace odcore {
             }
 
             uint16_t POSIXUDPSender::getPort() const {
-                return m_sendPort;
+                return m_sendingUDPPort;
             }
 
             void POSIXUDPSender::send(const string &data) const {

--- a/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPSender.cpp
+++ b/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPSender.cpp
@@ -21,6 +21,8 @@
 
 #include <cerrno>
 #include <cstring>
+
+#include <iostream>
 #include <sstream>
 
 #include "opendavinci/odcore/wrapper/Mutex.h"
@@ -34,6 +36,7 @@ namespace odcore {
             using namespace std;
 
             POSIXUDPSender::POSIXUDPSender(const string &address, const uint32_t &port) :
+                m_sendPort(0),
                 m_address(),
                 m_fd(),
                 m_socketMutex() {
@@ -52,7 +55,26 @@ namespace odcore {
                     throw s.str();
                 }
 
-                // Setup address and port.
+                // Bind to random address/port but store sender port.
+                struct sockaddr_in sendAddress;
+                memset(&sendAddress, 0, sizeof(sendAddress));
+                m_address.sin_family = AF_INET;
+                m_address.sin_port = 0; // Choose random port.
+                if (::bind(m_fd, reinterpret_cast<struct sockaddr *>(&sendAddress), sizeof(sendAddress)) < 0) {
+                    stringstream s;
+                    s << "[core::wrapper::POSIXUDPSender] Error while binding socket: " << strerror(errno);
+                    throw s.str();
+                }
+                struct sockaddr addr;
+                socklen_t len = sizeof(addr);
+                if (::getsockname(m_fd, &addr, &len) < 0) {
+                    stringstream s;
+                    s << "[core::wrapper::POSIXUDPSender] Error while retrieving properties from socket: " << strerror(errno);
+                    throw s.str();
+                }
+                m_sendPort = ntohs(((struct sockaddr_in *)&addr)->sin_port);
+
+                // Setup address and port to be used for sending to.
                 memset(&m_address, 0, sizeof(m_address));
                 m_address.sin_family = AF_INET;
                 m_address.sin_addr.s_addr = inet_addr(address.c_str());
@@ -67,6 +89,10 @@ namespace odcore {
                 close(m_fd);
             }
 
+            uint16_t POSIXUDPSender::getPort() const {
+                return m_sendPort;
+            }
+
             void POSIXUDPSender::send(const string &data) const {
                 if (data.length() > POSIXUDPSender::MAX_UDP_PACKET_SIZE) {
                     stringstream s;
@@ -74,11 +100,13 @@ namespace odcore {
                     throw s.str();
                 }
 
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
                 m_socketMutex->lock();
                 {
                     sendto(m_fd, data.c_str(), data.length(), 0, reinterpret_cast<const struct sockaddr *>(&m_address), sizeof(m_address));
                 }
                 m_socketMutex->unlock();
+std::cout << __FILE__ << " " << __LINE__ << std::endl;
             }
 
         }

--- a/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPSender.cpp
+++ b/libopendavinci/src/odcore/wrapper/POSIX/POSIXUDPSender.cpp
@@ -70,7 +70,6 @@ namespace odcore {
                     s << "[core::wrapper::POSIXUDPSender] Error while retrieving properties from socket: " << strerror(errno);
                     throw s.str();
                 }
-//                m_sendingUDPPort = ntohs(((struct sockaddr_in *)&addr)->sin_port);
                 m_sendingUDPPort = ntohs(reinterpret_cast<struct sockaddr_in*>(&addr)->sin_port);
 
                 // Setup address and port to be used for sending to.

--- a/libopendavinci/testsuites/DataTriggeredConferenceClientModuleTestSuite.h
+++ b/libopendavinci/testsuites/DataTriggeredConferenceClientModuleTestSuite.h
@@ -827,7 +827,7 @@ class DataTriggeredConferenceClientModuleTest : public CxxTest::TestSuite,
             string argv0("PingTimeTriggeredConferenceClientModuleTestModule");
             string argv1("--id=0");
             string argv2("--cid=105");
-            string argv3("--freq=1");
+            string argv3("--freq=10");
             int argc = 4;
             char **argv;
             argv = new char*[argc];

--- a/libopendavinci/testsuites/DataTriggeredConferenceClientModuleTestSuite.h
+++ b/libopendavinci/testsuites/DataTriggeredConferenceClientModuleTestSuite.h
@@ -307,7 +307,7 @@ class PingTimeTriggeredConferenceClientModuleTestModule : public TimeTriggeredCo
             TestSuiteExample7Data t;
             if (c.getDataType() == t.getID()+1000) {
                 t = c.getData<TestSuiteExample7Data>();
-                cout << "PingTimeTriggeredConferenceClientModuleTestModule: " << t.getNumericalValue() << endl;
+                cout << "PingTimeTriggeredConferenceClientModuleTestModule/" << t.getID()+1000 << ": " << t.getNumericalValue() << endl;
 
                 t.setNumericalValue(t.getNumericalValue()+1000);
 
@@ -357,7 +357,7 @@ class PongDataTriggeredConferenceClientModuleTestModule : public DataTriggeredCo
             TestSuiteExample7Data t;
             if (c.getDataType() == t.getID()) {
                 t = c.getData<TestSuiteExample7Data>();
-                cout << "PongDataTriggeredConferenceClientModuleTestModule: " << t.getNumericalValue() << endl;
+                cout << "PongDataTriggeredConferenceClientModuleTestModule/" << t.getID() << ": " << t.getNumericalValue() << endl;
                 t.setNumericalValue(t.getNumericalValue()+1000);
 
                 // Create container with user data type ID 5.
@@ -367,7 +367,7 @@ class PongDataTriggeredConferenceClientModuleTestModule : public DataTriggeredCo
             }
             if (c.getDataType() == t.getID()+2000) {
                 t = c.getData<TestSuiteExample7Data>();
-                cout << "PongDataTriggeredConferenceClientModuleTestModule+2000: " << t.getNumericalValue() << endl;
+                cout << "PongDataTriggeredConferenceClientModuleTestModule/" << t.getID()+2000 << ": " << t.getNumericalValue() << endl;
             }
         }
 
@@ -410,7 +410,7 @@ class DataTriggeredConferenceClientModuleTest : public CxxTest::TestSuite,
             m_connection = mc;
         }
 
-        void notestTimeTriggeredTimeTriggeredConferenceClientModule() {
+        void testTimeTriggeredTimeTriggeredConferenceClientModule() {
             // Setup ContainerConference.
             std::shared_ptr<ContainerConference> conference = ContainerConferenceFactory::getInstance().getContainerConference("225.0.0.101");
 
@@ -480,7 +480,7 @@ class DataTriggeredConferenceClientModuleTest : public CxxTest::TestSuite,
             Thread::usleepFor(1000 * 1);
         }
 
-        void notestDataTriggeredTimeTriggeredConferenceClientModules() {
+        void testDataTriggeredTimeTriggeredConferenceClientModules() {
             // Setup ContainerConference.
             std::shared_ptr<ContainerConference> conference = ContainerConferenceFactory::getInstance().getContainerConference("225.0.0.102");
 
@@ -584,7 +584,7 @@ class DataTriggeredConferenceClientModuleTest : public CxxTest::TestSuite,
             Thread::usleepFor(1000 * 1);
         }
 
-        void notestDataTriggeredTimeTriggeredConferenceClientModulesFreq10() {
+        void testDataTriggeredTimeTriggeredConferenceClientModulesFreq10() {
             // Setup ContainerConference.
             std::shared_ptr<ContainerConference> conference = ContainerConferenceFactory::getInstance().getContainerConference("225.0.0.103");
 
@@ -690,7 +690,7 @@ class DataTriggeredConferenceClientModuleTest : public CxxTest::TestSuite,
             Thread::usleepFor(1000 * 1);
         }
 
-        void notestDataTriggeredTimeTriggeredConferenceClientModulesFreq10WaitForSetupCompleted() {
+        void testDataTriggeredTimeTriggeredConferenceClientModulesFreq10WaitForSetupCompleted() {
             // Setup ContainerConference.
             std::shared_ptr<ContainerConference> conference = ContainerConferenceFactory::getInstance().getContainerConference("225.0.0.104");
 

--- a/libopendavinci/testsuites/DataTriggeredConferenceClientModuleTestSuite.h
+++ b/libopendavinci/testsuites/DataTriggeredConferenceClientModuleTestSuite.h
@@ -304,11 +304,8 @@ class PingTimeTriggeredConferenceClientModuleTestModule : public TimeTriggeredCo
         virtual void setUp() {}
 
         virtual void nextContainer(Container &c) {
-cout << __FILE__ << " " << __LINE__ << endl;
             TestSuiteExample7Data t;
-cout << __FILE__ << " " << __LINE__ << endl;
             if (c.getDataType() == t.getID()+1000) {
-cout << __FILE__ << " " << __LINE__ << endl;
                 t = c.getData<TestSuiteExample7Data>();
                 cout << "PingTimeTriggeredConferenceClientModuleTestModule: " << t.getNumericalValue() << endl;
 
@@ -316,21 +313,17 @@ cout << __FILE__ << " " << __LINE__ << endl;
 
                 // Create container with user data type ID 5.
                 Container c2(t, t.getID()+2000);
-cout << __FILE__ << " " << __LINE__ << endl;
 
                 // Send container.
                 getConference().send(c2);
-cout << __FILE__ << " " << __LINE__ << endl;
             }
         }
 
         virtual odcore::data::dmcp::ModuleExitCodeMessage::ModuleExitCode body() {
-cout << __FILE__ << " " << __LINE__ << endl;
             while (getModuleStateAndWaitForRemainingTimeInTimeslice() == odcore::data::dmcp::ModuleStateMessage::RUNNING) {
                 if (counter-- < 0) {
                     break;
                 }
-cout << __FILE__ << " " << __LINE__ << endl;
 
                 // Create user data.
                 TestSuiteExample7Data data;
@@ -338,22 +331,17 @@ cout << __FILE__ << " " << __LINE__ << endl;
 
                 // Create container with user data type ID 5.
                 Container c(data);
-cout << __FILE__ << " " << __LINE__ << endl;
 
                 // Send container.
                 getConference().send(c);
-cout << __FILE__ << " " << __LINE__ << endl;
             }
-cout << __FILE__ << " " << __LINE__ << endl;
 
             return odcore::data::dmcp::ModuleExitCodeMessage::OKAY;
         }
 
         virtual void tearDown() {
-cout << __FILE__ << " " << __LINE__ << endl;
             Lock l(m_condition);
             m_condition.wakeAll();
-cout << __FILE__ << " " << __LINE__ << endl;
         }
 };
 
@@ -370,16 +358,12 @@ class PongDataTriggeredConferenceClientModuleTestModule : public DataTriggeredCo
             if (c.getDataType() == t.getID()) {
                 t = c.getData<TestSuiteExample7Data>();
                 cout << "PongDataTriggeredConferenceClientModuleTestModule: " << t.getNumericalValue() << endl;
-cout << __FILE__ << " " << __LINE__ << endl;
                 t.setNumericalValue(t.getNumericalValue()+1000);
-cout << __FILE__ << " " << __LINE__ << endl;
 
                 // Create container with user data type ID 5.
                 Container c2(t, t.getID()+1000);
-cout << __FILE__ << " " << __LINE__ << endl;
                 // Send container.
                 getConference().send(c2);
-cout << __FILE__ << " " << __LINE__ << endl;
             }
             if (c.getDataType() == t.getID()+2000) {
                 t = c.getData<TestSuiteExample7Data>();
@@ -877,28 +861,20 @@ class DataTriggeredConferenceClientModuleTest : public CxxTest::TestSuite,
 
             ConferenceClientModuleTestService ccmts(ttccmtm);
             ccmts.start();
-cout << __FILE__ << " " << __LINE__ << endl;
 
             Lock l(module1);
             module1.waitOnSignal();
 
-cout << __FILE__ << " " << __LINE__ << endl;
             ccmts_d.stop();
-cout << __FILE__ << " " << __LINE__ << endl;
             ccmts.stop();
-cout << __FILE__ << " " << __LINE__ << endl;
 
             Thread::usleepFor(1000 * 3);
 #endif
 
             // Ugly cleanup.
-cout << __FILE__ << " " << __LINE__ << endl;
             ContainerConferenceFactory &ccf = ContainerConferenceFactory::getInstance();
-cout << __FILE__ << " " << __LINE__ << endl;
             ContainerConferenceFactory *ccf2 = &ccf;
-cout << __FILE__ << " " << __LINE__ << endl;
             OPENDAVINCI_CORE_DELETE_POINTER(ccf2);
-cout << __FILE__ << " " << __LINE__ << endl;
 
             Thread::usleepFor(1000 * 1);
         }

--- a/libopendavinci/testsuites/DataTriggeredConferenceClientModuleTestSuite.h
+++ b/libopendavinci/testsuites/DataTriggeredConferenceClientModuleTestSuite.h
@@ -28,7 +28,6 @@
 #include "cxxtest/TestSuite.h"          // for TS_ASSERT, TestSuite
 
 #include "opendavinci/odcore/opendavinci.h"
-#include "opendavinci/odcore/base/Thread.h"
 #include "opendavinci/odcore/base/Condition.h"        // for Condition
 #include "opendavinci/odcore/serialization/Deserializer.h"     // for Deserializer
 #include "opendavinci/odcore/base/KeyValueConfiguration.h"  // for KeyValueConfiguration

--- a/tutorials/datatrigger/README.rst
+++ b/tutorials/datatrigger/README.rst
@@ -352,6 +352,12 @@ before ``odsupercomponent`` can be started::
 
    $ sudo route add -net 224.0.0.0 netmask 240.0.0.0 dev lo
 
+If you use the ``ip`` command, you need to do::
+
+   $ sudo ip link set lo multicast on
+
+   $ sudo ip route add 224.0.0.0/4 dev lo
+
 Next, we can run the life-cycle management application ``odsupercomponent``::
 
    $ odsupercomponent --cid=111 --configuration=/path/to/configuration

--- a/tutorials/timetrigger/README.rst
+++ b/tutorials/timetrigger/README.rst
@@ -142,6 +142,12 @@ before ``odsupercomponent`` can be started::
 
    $ sudo route add -net 224.0.0.0 netmask 240.0.0.0 dev lo
 
+If you use the ``ip`` command, you need to do::
+
+   $ sudo ip link set lo multicast on
+
+   $ sudo ip route add 224.0.0.0/4 dev lo
+
 Next, we can run the life-cycle management application ``odsupercomponent``::
 
    $ odsupercomponent --cid=111 --configuration=/path/to/configuration


### PR DESCRIPTION
* Fixed double lock in ContainerConference preventing getConference().send() in nextContainer(...); lines 52 + 57
* Avoid sending data circularly (UDP socket for receiving would react on the UDP socket used for sending in the same process):
* Added Ping/Pong test case to test behavior

TODO:
* add WIN32 implementation for UDP port sender protection
* find sender IP (currently: 0.0.0.0)