### PR TITLE
2017Q1.fix.odcockpit.cwd

### DIFF
--- a/odcockpit/include/CockpitWindow.h
+++ b/odcockpit/include/CockpitWindow.h
@@ -75,6 +75,9 @@ namespace plugins { class PlugInProvider; }
 
             virtual ~CockpitWindow();
 
+            static string getStartupDirectory();
+            static string m_startupDirectory;
+
         public slots:
             void close();
             void maximizeActiveSubWindow();

--- a/odcockpit/include/plugins/environmentviewer/EnvironmentViewerGLWidget.h
+++ b/odcockpit/include/plugins/environmentviewer/EnvironmentViewerGLWidget.h
@@ -22,8 +22,9 @@
 #define PLUGINS_ENVIRONMENTVIEWER_ENVIRONMENTVIEWERGLWIDGET_H_
 
 #include <map>
-#include <vector>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "opendavinci/odcore/opendavinci.h"
 #include "opendavinci/odcore/base/Mutex.h"
@@ -135,6 +136,7 @@ class SelectableNodeDescriptor;
 
                     odcore::base::TreeNode<SelectableNodeDescriptor> *m_selectableNodeDescriptorTree;
                     SelectableNodeDescriptorTreeListener &m_selectableNodeDescriptorTreeListener;
+
                     std::shared_ptr<odcore::wrapper::SharedMemory> m_velodyneSharedMemory;
                     bool m_hasAttachedToSharedImageMemory;
                     odcore::data::SharedPointCloud m_velodyneFrame;

--- a/odcockpit/src/CockpitWindow.cpp
+++ b/odcockpit/src/CockpitWindow.cpp
@@ -21,6 +21,7 @@
 #include <QtCore>
 #include <QtGui>
 
+#include <iostream>
 #include <string>
 
 #include "opendavinci/odcore/opendavinci.h"
@@ -39,6 +40,8 @@ namespace cockpit {
     using namespace odcore::base;
     using namespace odcore::io::conference;
 
+    string CockpitWindow::m_startupDirectory = ".";
+
     CockpitWindow::CockpitWindow(const KeyValueConfiguration &kvc, DataStoreManager &dsm, ContainerConference &conf) :
         m_kvc(kvc),
         m_dataStoreManager(dsm),
@@ -49,6 +52,7 @@ namespace cockpit {
         m_fileMenu(NULL),
         m_windowMenu(NULL),
         m_availablePlugInsList(NULL) {
+getStartupDirectory();
     	m_multiplexer = new FIFOMultiplexer(dsm);
         constructLayout();
     }
@@ -56,6 +60,14 @@ namespace cockpit {
     CockpitWindow::~CockpitWindow() {
         m_multiplexer->stop();
         OPENDAVINCI_CORE_DELETE_POINTER(m_multiplexer);
+    }
+
+    string CockpitWindow::getStartupDirectory() {
+        if (CockpitWindow::m_startupDirectory.at(0) == '.') {
+            CockpitWindow::m_startupDirectory = QDir::current().absolutePath().toStdString() + "/";
+            cout << "[odcockpit] Startup directory: '" << CockpitWindow::m_startupDirectory << "'" << endl;
+        }
+        return CockpitWindow::m_startupDirectory;
     }
 
     void CockpitWindow::constructLayout() {

--- a/odcockpit/src/plugins/birdseyemap/BirdsEyeMapMapWidget.cpp
+++ b/odcockpit/src/plugins/birdseyemap/BirdsEyeMapMapWidget.cpp
@@ -44,6 +44,8 @@
 #include "opendlv/scenegraph/primitives/Polygon.h"
 #include "opendlv/scenegraph/renderer/SceneNodeRenderingConfiguration.h"
 #include "opendlv/scenegraph/transformation/SceneGraphFactory.h"
+
+#include "CockpitWindow.h"
 #include "plugins/PlugIn.h"
 #include "plugins/birdseyemap/BirdsEyeMapMapWidget.h"
 #include "plugins/birdseyemap/BirdsEyeMapRenderer.h"
@@ -151,6 +153,11 @@ namespace cockpit {
             }
 
             void BirdsEyeMapMapWidget::createSceneGraph() {
+                // The .scnx and .objx files are provided relative to the location of odcockpit.
+                // Thus, set the correct CWD.
+                QString cwd(CockpitWindow::getStartupDirectory().c_str());
+                QDir::setCurrent(cwd);
+
                 // Setup surroundings.
                 const URL urlOfSCNXFile(m_plugIn.getKeyValueConfiguration().getValue<string>("global.scenario"));
                 if (urlOfSCNXFile.isValid()) {

--- a/odcockpit/src/plugins/environmentviewer/EnvironmentViewerGLWidget.cpp
+++ b/odcockpit/src/plugins/environmentviewer/EnvironmentViewerGLWidget.cpp
@@ -61,6 +61,8 @@
 #include "opendlv/threeD/models/Line.h"
 #include "opendlv/threeD/models/Point.h"
 #include "opendlv/threeD/models/XYZAxes.h"
+
+#include "CockpitWindow.h"
 #include "plugins/PlugIn.h"
 #include "plugins/environmentviewer/CameraAssignableNodesListener.h"
 #include "plugins/environmentviewer/EnvironmentViewerGLWidget.h"
@@ -134,6 +136,11 @@ namespace cockpit {
             }
 
             void EnvironmentViewerGLWidget::createSceneGraph() {
+                // The .scnx and .objx files are provided relative to the location of odcockpit.
+                // Thus, set the correct CWD.
+                QString cwd(CockpitWindow::getStartupDirectory().c_str());
+                QDir::setCurrent(cwd);
+
                 m_root = new TransformGroup();
                 m_stationaryElements = new TransformGroup();
                 m_dynamicElements = new TransformGroup();


### PR DESCRIPTION
Fixing odcockpit to avoid crashes when the current working directory is different from where the .scnx and .objx files are expected to be according to the configuration file