### PR TITLE
2017Q1.fix.failed.containerdecoding

### DIFF
--- a/libopendavinci/src/odcore/data/Container.cpp
+++ b/libopendavinci/src/odcore/data/Container.cpp
@@ -253,6 +253,7 @@ namespace odcore {
                         // Check validity of the received bytes.
                         if (!( (0x0D == byte0) && (0xA4 == byte1) )) {
                             std::cerr << "[core::base::Container] Failed to decode OpenDaVINCI container header." << std::endl;
+                            return in;
                         }
                     }
                 }


### PR DESCRIPTION
* Return istream if no container could be decoded